### PR TITLE
Added ILMerge to the project

### DIFF
--- a/ObsidianX.Rainmeter.Nest/ILMerge.props
+++ b/ObsidianX.Rainmeter.Nest/ILMerge.props
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!--                                                                                   -->
+    <!-- ILMerge project-specific settings. Almost never need to be set explicitly.       -->
+    <!-- for details, see http://research.microsoft.com/en-us/people/mbarnett/ilmerge.aspx -->
+    <!--                                                                                   -->
+    <!-- *** set this file to Type=None, CopyToOutput=Never ***                            -->
+
+    <!-- If True, all copy local dependencies will also be merged from referenced projects whether they are referenced in the current project explicitly or not -->
+    <ILMergeTransitive>true</ILMergeTransitive>
+
+    <!-- Extra ILMerge library paths (semicolon-separated). Dont put your package dependencies here, they will be added automagically -->
+    <ILMergeLibraryPath></ILMergeLibraryPath>
+
+    <!-- The solution NuGet package directory if not standard 'SOLUTION\packages' -->
+    <ILMergePackagesPath></ILMergePackagesPath>
+
+    <!-- The merge order file name if differs from standard 'ILMergeOrder.txt' -->
+    <ILMergeOrderFile></ILMergeOrderFile>
+
+    <!-- The strong key file name if not specified in the project -->
+    <ILMergeKeyFile></ILMergeKeyFile>
+
+    <!-- The assembly version if differs for the version of the main assembly -->
+    <ILMergeAssemblyVersion></ILMergeAssemblyVersion>
+
+    <!-- added in Version 1.0.4 -->
+    <ILMergeFileAlignment></ILMergeFileAlignment>
+
+    <!-- added in Version 1.0.4, default=none -->
+    <ILMergeAllowDuplicateType></ILMergeAllowDuplicateType>
+
+    <!-- If the <see cref="CopyAttributes"/> is also set, any assembly-level attributes names that have the same type are copied over into the target assembly -->
+    <ILMergeAllowMultipleAssemblyLevelAttributes></ILMergeAllowMultipleAssemblyLevelAttributes>
+
+    <!-- See ILMerge documentation -->
+    <ILMergeAllowZeroPeKind></ILMergeAllowZeroPeKind>
+
+    <!-- The assembly level attributes of each input assembly are copied over into the target assembly -->
+    <ILMergeCopyAttributes></ILMergeCopyAttributes>
+    
+    <!-- Creates a .pdb file for the output assembly and merges into it any .pdb files found for input assemblies, default=true -->
+    <ILMergeDebugInfo></ILMergeDebugInfo>
+
+    <!-- Target assembly will be delay signed -->
+    <ILMergeDelaySign></ILMergeDelaySign>
+
+    <!-- Types in assemblies other than the primary assembly have their visibility modified -->
+    <ILMergeInternalize></ILMergeInternalize>
+
+    <!-- The path name of the file that will be used to identify types that are not to have their visibility modified -->
+    <ILMergeInternalizeExcludeFile></ILMergeInternalizeExcludeFile>
+
+    <!-- XML documentation files are merged to produce an XML documentation file for the target assembly -->
+    <ILMergeXmlDocumentation></ILMergeXmlDocumentation>
+
+    <!-- External assembly references in the manifest of the target assembly will use full public keys (false) or public key tokens (true, default value) -->
+    <ILMergePublicKeyTokens></ILMergePublicKeyTokens>
+
+    <!-- Types with the same name are all merged into a single type in the target assembly -->
+    <ILMergeUnionMerge></ILMergeUnionMerge>
+
+    <!-- The version of the target framework, default 40 (works for 45 too) -->
+    <ILTargetPlatform></ILTargetPlatform>
+  </PropertyGroup>
+</Project>

--- a/ObsidianX.Rainmeter.Nest/ILMergeOrder.txt
+++ b/ObsidianX.Rainmeter.Nest/ILMergeOrder.txt
@@ -1,0 +1,4 @@
+﻿# this file contains the partial list of the merged assemblies in the merge order
+# you can fill it from the obj\CONFIG\PROJECT.ilmerge generated on every build
+# and finetune merge order to your satisfaction
+

--- a/ObsidianX.Rainmeter.Nest/ObsidianX.Rainmeter.Nest.csproj
+++ b/ObsidianX.Rainmeter.Nest/ObsidianX.Rainmeter.Nest.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props" Condition="Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <AssemblyName>ObsidianX.Rainmeter.Nest</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -51,7 +54,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="ObsidianX.Web.EventSource, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -77,9 +80,21 @@
     <Compile Include="ReporterPlugin.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="ILMerge.props" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="ILMergeOrder.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.props'))" />
+    <Error Condition="!Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets" Condition="Exists('..\packages\MSBuild.ILMerge.Task.1.0.5\build\MSBuild.ILMerge.Task.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ObsidianX.Rainmeter.Nest/packages.config
+++ b/ObsidianX.Rainmeter.Nest/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ILMerge" version="2.14.1208" targetFramework="net45" />
+  <package id="MSBuild.ILMerge.Task" version="1.0.5" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This should mean that the project now generates a single .dll file which
is much more well suited for Rainmeter. I am unable to test it since I do not have a nest but the .dll file looked correct when I decompiled it.

Also not to nag but I would probably switch to using post build events instead of the .bat file for easier debugging but that is just like my opinion dude.